### PR TITLE
Update werewolf/style.css

### DIFF
--- a/bbs/skin/werewolf/style.css
+++ b/bbs/skin/werewolf/style.css
@@ -298,7 +298,9 @@ label, .buttonCommentPage{cursor: pointer;}
 #timer{
 }
 
-BODY,TD,input,div,form,TEXTAREA,center,option,pre,blockquote {font-size:9pt;color:#666666;font-family:±¼¸²;}
+BODY,TD,input,div,form,TEXTAREA,center,option,pre,blockquote {font-size:9pt;color:#666666;font-family:Â±Â¼Â¸Â²;}
+TEXTAREA {-webkit-text-size-adjust: 100%}
+
 TD {line-height:140%}
 input {border:solid 0;border-color:ffffff}
 
@@ -317,17 +319,17 @@ body{
 	*/
 }
 
-A:link    {color:666666;text-decoration:none;font-family:±¼¸²;font-size:9pt;}
-A:visited {color:666666;text-decoration:none;font-family:±¼¸²;font-size:9pt;}
-A:active  {color:ff6666;text-decoration:none;font-family:±¼¸²;font-size:9pt;}
-A:hover  {color:666666;text-decoration:none;font-family:±¼¸²;font-size:9pt;}
+A:link    {color:666666;text-decoration:none;font-family:Â±Â¼Â¸Â²;font-size:9pt;}
+A:visited {color:666666;text-decoration:none;font-family:Â±Â¼Â¸Â²;font-size:9pt;}
+A:active  {color:ff6666;text-decoration:none;font-family:Â±Â¼Â¸Â²;font-size:9pt;}
+A:hover  {color:666666;text-decoration:none;font-family:Â±Â¼Â¸Â²;font-size:9pt;}
 
 
-.red_8 {font-family:±¼¸²;font-size:9pt;color:#666666}
-.red_7 {font-family:±¼¸²;font-size:8pt;color:#666666}
+.red_8 {font-family:Â±Â¼Â¸Â²;font-size:9pt;color:#666666}
+.red_7 {font-family:Â±Â¼Â¸Â²;font-size:8pt;color:#666666}
 
 
-.red_comment {font-family:±¼¸²;font-size:7pt;}
+.red_comment {font-family:Â±Â¼Â¸Â²;font-size:7pt;}
 .red_search {border:solid 1;border-color:eeeeee;height:18px;width:100px;color:666666;}
 .red_input {border:solid 1;border-color:eeeeee}
 .red_textarea {border:solid 1;border-color:eeeeee;background-color:FFFDFB;width:350;}


### PR DESCRIPTION
하고 싶었던 건
게임 내 TextArea 영역에 {-webkit-text-size-adjust: 100%} style 추가였습니다만,
github console에서 수정하니 파일 인코딩을 utf-8로 변경하는 과정에서
의도치 않은 수정 내용이 들어가게 되었습니다.

문제 있을 시엔 아래 ref 링크 검토 부탁드립니다.

### Abstract
* [Issue - 모바일에서 시스템적으로 장문로그 쓰기 불편하네요.](http://werewolf.co.kr/bbs/zboard.php?id=wolfFree&page=1&sn1=&divpage=2&sn=off&ss=on&sc=on&select_arrange=headnum&desc=asc&no=9466)
* 모바일에서 보내기 버튼 가려지는 버그 수정
* 화면 회전에 따른 폰트 리사이즈 문제로 예상

### ref
* http://stackoverflow.com/questions/2710764/preserve-html-font-size-when-iphone-orientation-changes-from-portrait-to-landsca
* https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/AdjustingtheTextSize/AdjustingtheTextSize.html#//apple_ref/doc/uid/TP40006510-SW16